### PR TITLE
Fix to do not install sphinx on Windows

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,8 +10,8 @@ nifcloud-cli = {editable = true, path = "."}
 isort = "*"
 "flake8" = "*"
 cx-freeze = "==6.13.1"
-sphinx = "==5.3.0"
-sphinx-rtd-theme = "*"
+sphinx = {version = "==5.3.0", sys_platform = "!= 'win32'"}
+sphinx-rtd-theme = {version = "*", sys_platform = "!= 'win32'"}
 
 [scripts]
 isort = "isort"


### PR DESCRIPTION
# Summary

- Fix to skip installing the sphinx on windows because sphinx-rtd-theme cannot install to windows.
```
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\importlib\__init__.py", line 169, in reload
    _bootstrap._exec(spec, module)
  File "<frozen importlib._bootstrap>", line 613, in _exec
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\pkg_resources\__init__.py", line 74, in <module>
    from pkg_resources.extern.jaraco.text import (
ModuleNotFoundError: No module named 'pkg_resources.extern.jaraco'
```

Reference: https://pipenv-fork.readthedocs.io/en/latest/advanced.html#specifying-basically-anything