### PR TITLE
Add waiter for remote access vpn gateway

### DIFF
--- a/nifcloudcli/data/computing/3.0/waiters-2.json
+++ b/nifcloudcli/data/computing/3.0/waiters-2.json
@@ -741,7 +741,55 @@
           "state": "retry"
         }
       ]
+    },
+    "RemoteAccessVpnGatewayExists": {
+      "delay": 20,
+      "maxAttempts": 40,
+      "operation": "DescribeRemoteAccessVpnGateways",
+      "acceptors": [
+        {
+          "matcher": "path",
+          "expected": true,
+          "argument": "length(RemoteAccessVpnGatewaySet[]) > `0`",
+          "state": "success"
+        },
+        {
+          "matcher": "error",
+          "expected": "Client.InvalidParameterNotFound.RemoteAccessVpnGatewayId",
+          "state": "retry"
+        }
+      ]
+    },
+    "RemoteAccessVpnGatewayAvailable": {
+      "delay": 20,
+      "operation": "DescribeRemoteAccessVpnGateways",
+      "maxAttempts": 40,
+      "acceptors": [
+        {
+          "matcher": "pathAll",
+          "expected": "available",
+          "state": "success",
+          "argument": "RemoteAccessVpnGatewaySet[].Status"
+        }
+      ]
+    },
+    "RemoteAccessVpnGatewayDeleted": {
+      "delay": 20,
+      "operation": "DescribeRemoteAccessVpnGateways",
+      "maxAttempts": 40,
+      "acceptors": [
+        {
+          "matcher": "error",
+          "expected": "Client.InvalidParameterNotFound.RemoteAccessVpnGatewayId",
+          "state": "success"
+        },
+        {
+          "matcher": "path",
+          "expected": true,
+          "argument": "length(RemoteAccessVpnGatewaySet[]) == `0`",
+          "state": "success"
+        }
+      ]
     }
   }
 }
-


### PR DESCRIPTION
Add waiter for RemoteAccessVpnGateway


- [ ] `PYTHONPATH=. python bin/nifcloud computing wait remote-access-vpn-gateway-deleted --remote-access-vpn-gateway-id ravgw-12345678` succeeded.
    - `ravgw-12345678` does not exist, so this command exits immediately.
- [ ] enjoi!!