### PR TITLE
Feature/update python and pipenv version

### DIFF
--- a/.github/workflows/publish-to-release.yml
+++ b/.github/workflows/publish-to-release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install pipenv==2023.5.19
+          pip install pipenv==2023.5.19 setuptools wheel
           pipenv install -d --skip-lock --system
 
       - name: Build exe

--- a/.github/workflows/publish-to-release.yml
+++ b/.github/workflows/publish-to-release.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.11]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/publish-to-release.yml
+++ b/.github/workflows/publish-to-release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install pipenv==2021.05.29
+          pip install pipenv==2023.5.19
           pipenv install -d --skip-lock --system
 
       - name: Build exe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.11]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install pipenv
-        run: pip install pipenv==2021.05.29
+        run: pip install pipenv==2023.5.19
 
       - name: Install dependencies
         run: pipenv install --skip-lock -d

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ ENV PATH="/home/nifcloud/.local/bin:${PATH}"
 COPY . .
 COPY bin/nifcloud /usr/local/bin/nifcloud
 
-RUN pip install pipenv==2021.5.29 --no-cache-dir --user && pipenv install --system --deploy && pip uninstall -y pipenv
+RUN pip install pipenv==2023.5.19 --no-cache-dir --user && pipenv install --system --deploy && pip uninstall -y pipenv
 
 ENTRYPOINT ["/usr/local/bin/nifcloud"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG PYTHON_VERSION="3.9.7"
+ARG PYTHON_VERSION="3.11.3"
 
-FROM python:${PYTHON_VERSION}-alpine3.14
+FROM python:${PYTHON_VERSION}-alpine3.18
 
 RUN apk --update add groff
 

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ nifcloud-cli = {editable = true, path = "."}
 [dev-packages]
 isort = "*"
 "flake8" = "*"
-cx-freeze = "==6.13.1"
+cx-freeze = "==6.15.0"
 sphinx = {version = "==5.3.0", sys_platform = "!= 'win32'"}
 sphinx-rtd-theme = {version = "*", sys_platform = "!= 'win32'"}
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d580056ddcfafabec3768173aeafd7c22083707da53fc747e032e6cc41daafd8"
+            "sha256": "f7e828a9d94cc35b3ab982e77480af8d8e6c902fb5d3b72eb73936a36e5c53eb"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -44,7 +44,7 @@
                 "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
                 "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.15.2"
         },
         "jmespath": {
@@ -52,7 +52,7 @@
                 "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
                 "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.0"
         },
         "nifcloud": {
@@ -79,7 +79,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
         },
         "pyyaml": {
@@ -138,16 +138,16 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305",
-                "sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42"
+                "sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f",
+                "sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.26.15"
+            "version": "==1.26.16"
         }
     },
     "develop": {
@@ -169,11 +169,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
-                "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
+                "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7",
+                "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.12.7"
+            "version": "==2023.5.7"
         },
         "charset-normalizer": {
             "hashes": [
@@ -253,49 +253,56 @@
                 "sha256:f8303414c7b03f794347ad062c0516cee0e15f7a612abd0ce1e25caf6ceb47df",
                 "sha256:fca62a8301b605b954ad2e9c3666f9d97f63872aa4efcae5492baca2056b74ab"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_full_version >= '3.7.0'",
             "version": "==3.1.0"
         },
         "cx-freeze": {
             "hashes": [
-                "sha256:002e453164cc3b5a467ff0975955d761c9dc9dcdf8b521ea2bd51e01e29d66cf",
-                "sha256:0228a18acaf65543da51fbc98a1eaac5025b388af4f5f82c4dc209390b59a8da",
-                "sha256:042967f5a6ab5dfb21f633264f1d9211a8db5b2acfa13d0f906bbc693f5e9c61",
-                "sha256:09e872bffaccc1829a3d4815103ece5bb7896ccaf5b5191d62fe758a359d0def",
-                "sha256:0daf25c745dcd95c05c657279557156890a3f8ca92add1b596d1d82bdc324b79",
-                "sha256:198624947984becd5a815008cdbacbdfe89a5b053f282e494bd6449a2094e42d",
-                "sha256:22750aa871be2ab5f82d53df0a96f122eee2f46f22e36fbbb298dcfef77affe9",
-                "sha256:2b311a52b6db09acf30cdeb6bf158db07049b95629d2c2d8a37055d6a99fa8a0",
-                "sha256:41fbe545c1249a05771352e5689e492af2b265c4f43f95faab9dd8e570f2d2e5",
-                "sha256:42a036796711906e79380b469f36f2f88ddc0cc965a55369f92f77ff0999db0c",
-                "sha256:4bb8af2a76455fe8446df3b7f33fd83502536c4195c7452055fc8bfb31b42598",
-                "sha256:4c65ded67f7e4f842ddf20260496fbc98192352ea1ae6e16827e3f25f0a9c53d",
-                "sha256:515b3bd89d964c66fb74c5a9caabddb4e53571dbe931ee50cbb9509a3900de89",
-                "sha256:5aa4926be340d8aafaa82ba13c62340308f4df5c4d1220118f43c9b3ff46e585",
-                "sha256:5cd143d6c7a9d4e7c6a9338856e3c8f0fc4fae6ef00e30d3fd4e49fe054ca5f5",
-                "sha256:5faae7ee72649553ed180a7f48500a85d4aa1ffe015fbc2fc9fee13f360efad3",
-                "sha256:62a4a84e89fe8b1aa3bfec28f19fe4badebd299883d96e8c1dbcbc4319d0ef80",
-                "sha256:64f08a0cb43fdbe3282bd2810e0b3835e90c568574d720cba79ab7ecaabc935c",
-                "sha256:65dc8f29a18a2a420483356e86d460b10fd7126072e6fc44d4c4da41bbb8d7ae",
-                "sha256:82154171b5c9f89b406723f378c469f3e9af367565d25d8185d5c51532dd5b17",
-                "sha256:83a684991c3c37d38a75f7804be62d831719ee0cb60b304e12dd5ace2ea939ef",
-                "sha256:8cb5f2271a680272c9861e551913acbaca145693740529e0d0fc4f13809536d6",
-                "sha256:8cd336f82d21f582092b45c0c88d05a571de9109ad62c381b797b7093374b1d8",
-                "sha256:93ae97072b31adfab51eb35f6e3c2e46654eff5bdfe8203538dbe93237ef6bc5",
-                "sha256:954faf882887734c0fc69b7d9db25c2e70c9ce44dc078289379a39fbd2053aa9",
-                "sha256:9ec94b8c9fdb262449c64de1fad0bfc41c41140836421a56991d33179ef2bb69",
-                "sha256:a087e3f02acd00219cab0207e5fd9af8980fde6c7e672c3a27c58f8e1cab6d05",
-                "sha256:b2a61f9e76a2c3f724790ae6e786f3efc7c3d5936d031958ea5c2ef05b884d91",
-                "sha256:b802cd5d6959fe5c9283c0a769e9b818fcd6b40aab0599755f1cb27d1378ad03",
-                "sha256:b9c1a423c877e42f17aa318577b7c82a4f90802bba27d645fd06bdf08f64392a",
-                "sha256:be9d8acec8104eea794550d4fb61940d68d80936e4aad3d33310ed2e5f2bbac3",
-                "sha256:cd90887ec7a0d3f2384170fbaf2fbe4ff49e0b838473ae6a0932f64974bd3c33",
-                "sha256:d6abf729e796e9d6d8eba7192ef6d98c5cd9764fa9ce767dff49533e84472def",
-                "sha256:f515cadd90d03ac860b8ec6d7e347bb383d5573f4aa9b8b13c17f368ae980e46",
-                "sha256:f694f54daf292e973d92b14df0a2e9ddbd74206caf32389a5370a7e1e54089a4"
+                "sha256:174449b685b641c84c456038fc1a3b4e860294ea349c549bb7a23f1f7bf18ae0",
+                "sha256:1980034ce36c019c7cb7aeae43fbc16faaac86d6b07fbd92d2692787574e924d",
+                "sha256:229e44ff29b76e60ed51a3d8e3286d6f872d2b56c850a6a0ec2778f48d518609",
+                "sha256:24abc4b25af3a6dc759472b23ab0c1ef649070ba682314d77180f15024373268",
+                "sha256:2cb9fd359b9427278c825874323053a21f6a74b86ab6f722b1bca6a424b87a34",
+                "sha256:2f34e7e3ee0af03f57c263c671eabead9881302c99f4dd9c2229d5ab1cd69bbb",
+                "sha256:3e8c00d79c4963d68a009a47b3984b322e64c05a0b4aa936804f2e573c045a34",
+                "sha256:4538bd43b293cd7601a44120bbd14f5ceb8566652803739157a3f4b9df636db0",
+                "sha256:4747af12796a6e083c0cf095581b7f84b81d7286b4930777dbf688ca0a2c9898",
+                "sha256:4e89eb2cf2570a7aa9b5ee5fabc226b48e710f673f923c21bb8363e08a7e0bfb",
+                "sha256:543e0c05fbc0a03aaa8b56a3e67bea1da800aa54cd9363d20db048e0afa1ade6",
+                "sha256:5d86c7d08ddd3cafbca29c7b4ca64276c6ab0abe2cdd582758dbe43fb757f2de",
+                "sha256:5e8de987aa49a5733064846d04359f10a6abd46003be2a94989a2da56c70ec97",
+                "sha256:60ed86a2f6e6150de9e2a456b2850fa8305b3b10769796a3167f6843eaa4a1ea",
+                "sha256:624c3b171b56a15e389b65018f9d6ad5497b8068da02bacfcc74ea3fbce1b61d",
+                "sha256:65a7985189b167014af4e2e9b62a7831dc55c2e5d49ad61301f82525738356f1",
+                "sha256:67b05188fd83ab03687cbfdd652b76b2e09587f7256125c0a8bf8e6dcb7591c1",
+                "sha256:743a6c3981cc784dfed14f7acbcdc8e59ba8526b958513c244c54e770d976317",
+                "sha256:78a9a785a4c1034bbd035f0e6698b725c0e0f36f7b221c2353e9f9cf3cfdb5cb",
+                "sha256:7e8fb2b8409b2715ecca3efcd644a0f57a4ed531636c875dcb0b99aca03a9b84",
+                "sha256:82739ed7ed1204c80ad47b3bfea952db5d72239951d7ad13300243f29b29db71",
+                "sha256:855d02e80163cc6614f92acf861f8ef24cb0df5fd1c5d23a319b95f89ad52347",
+                "sha256:8697e9fa46c0fff18b2468db08683818d70b1874a484fc3c2aa6faa77c6ca1d7",
+                "sha256:86def06eed007a092c0b335d77cab512b36c26ba68db79462ce9865cafd399c1",
+                "sha256:8dad161b00b50d06a676075612ac630fe652398c3ae17c0a010c7adbfcebce06",
+                "sha256:9175fd0dee12f54d71d93461464db82fef51027bb69f887c0b80d3068ee2461b",
+                "sha256:938b2695f86233e10c5bd7649d1e1b94ee2a36e0e45ec261a73206b30194ac0a",
+                "sha256:93e89f8831fce12162c45959899e69f26c6511a2e2f77d72867765f17902ef31",
+                "sha256:9764fd8404b2ef07bd298cc93c7adb3a463941ed82ad2475df6f210347a4a33b",
+                "sha256:9e4aedf3c540e4e0195094c6c76465f64077ba17bd0a9b47f217869e87b27200",
+                "sha256:a1c2a8b0d8cc66a829f1e56a6d8c9f5763e1d7cc357fb96388460f296286b349",
+                "sha256:aa0233725f6fa586bc2dc8cd352c435d19718f75ee5699046f0065ccf70d4e95",
+                "sha256:ac07a0baf0035e0d0329b8c7719ed12be9006fc9a7a79d110a1ee4c1a4ce6d69",
+                "sha256:af9f9af17c502df492841dfaa410ce2e59d27acbe0554ae9278919da22a5f1c6",
+                "sha256:b15cee7cb87694a3112174659a2abc7c4d206131122f157bb1a358712c0ea987",
+                "sha256:ba35d5590f61249ab04a313230d6d12afc10fba0a60e6a221b6e9026ce822f02",
+                "sha256:ba6204b4058e5954e96eec9b1f0364ee1e832ae466bf705719892d62e3aeb74d",
+                "sha256:c6b0243ff8b7c127ea0d4797ef04a8548d433a41d7a6bdd5b3674eb710c0aded",
+                "sha256:c85bfe14ce64f190baa1df55ea59cc538f3aaef6389b654746b195ee25b69442",
+                "sha256:cbc6185d9eecf889888ad44677cc07f87342836c98129901dd0d070ec2b03dab",
+                "sha256:e276b1c35efd859c047140e067046734fd23429e8f153bce9d084c27c008540f",
+                "sha256:f770f7790738409e5f2c877ef209d98cfa50c7b25a273ac85aff088329076898"
             ],
             "index": "pypi",
-            "version": "==6.13.1"
+            "version": "==6.15.0"
         },
         "docutils": {
             "hashes": [
@@ -303,7 +310,7 @@
                 "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
                 "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.15.2"
         },
         "flake8": {
@@ -428,7 +435,7 @@
                 "sha256:f47b5bdd6885cfb20abdd14c707d26eb6f499a7f52e911865548d4aa43385502",
                 "sha256:fc329da0e8f628bd836dfb8eaf523547e342351fa8f739bf2b3fe4a6db5a297c"
             ],
-            "markers": "sys_platform == 'linux'",
+            "markers": "sys_platform == 'linux' and platform_machine == 'x86_64'",
             "version": "==0.17.2.1"
         },
         "pycodestyle": {
@@ -457,11 +464,19 @@
         },
         "requests": {
             "hashes": [
-                "sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa",
-                "sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf"
+                "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
+                "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4'",
-            "version": "==2.28.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.31.0"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:5df61bf30bb10c6f756eb19e7c9f3b473051f48db77fddbe06ff2ca307df9a6f",
+                "sha256:62642358adc77ffa87233bc4d2354c4b2682d214048f500964dbe760ccedf102"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==67.8.0"
         },
         "snowballstemmer": {
             "hashes": [
@@ -481,12 +496,12 @@
         },
         "sphinx-rtd-theme": {
             "hashes": [
-                "sha256:a0d8bd1a2ed52e0b338cbe19c4b2eef3c5e7a048769753dac6a9f059c7b641b8",
-                "sha256:f823f7e71890abe0ac6aaa6013361ea2696fc8d3e1fa798f463e82bdb77eeff2"
+                "sha256:2cc9351176cbf91944ce44cefd4fab6c3b76ac53aa9e15d6db45a3229ad7f866",
+                "sha256:cf9a7dc0352cf179c538891cb28d6fad6391117d4e21c891776ab41dd6c8ff70"
             ],
             "index": "pypi",
             "markers": "sys_platform != 'win32'",
-            "version": "==1.2.0"
+            "version": "==1.2.1"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
@@ -517,7 +532,7 @@
                 "sha256:1620739f04e36a2c779f1a131a2dfd49b2fd07351bf1968ced074365933abc7a",
                 "sha256:f936030d7d0147dd026a4f2b5a57343d233f1fc7b363f68b3d4f1cb0993878ae"
             ],
-            "markers": "python_version > '3'",
+            "markers": "python_version >= '3.1'",
             "version": "==4.1"
         },
         "sphinxcontrib-jsmath": {
@@ -546,11 +561,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305",
-                "sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42"
+                "sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f",
+                "sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.26.15"
+            "version": "==1.26.16"
         }
     }
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,4 @@ license_file = LICENSE
 per-file-ignores =
     nifcloudcli/customizations/configure/get.py:E501
     nifcloudcli/customizations/configure/set.py:E501
+    build/**/*.py:E501

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ),
     scripts=['bin/nifcloud'],
     **cx_freeze_opts,


### PR DESCRIPTION
# Summary

- Update Python to 3.11
- Update Pipenv
- Update cx-freeze for new Python version
- Update some dependencies

# Tests

- [x] `docker build -t nifcloud-cli .`
- [x] `docker run --rm nifcloud-cli help` runs successfully.