### PR TITLE
Fix cxfreeze options

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ nifcloud-cli = {editable = true, path = "."}
 [dev-packages]
 isort = "*"
 "flake8" = "*"
-cx-freeze = "==6.15.0"
+cx-freeze = "==6.15.16"
 sphinx = {version = "==5.3.0", sys_platform = "!= 'win32'"}
 sphinx-rtd-theme = {version = "*", sys_platform = "!= 'win32'"}
 pytest = "*"

--- a/setup.py
+++ b/setup.py
@@ -8,18 +8,18 @@ if os.name == "nt" and ("build" in sys.argv or "bdist_msi" in sys.argv):
     from cx_Freeze import Executable, setup
     from setuptools import find_packages
 
-    if 'bdist_msi' in sys.argv:
-        sys.argv += ['--add-to-path', 'True', '--skip-build']
-
     build_exe_options = {
         "includes": ["awscli", "html.parser"],
         "packages": ["docutils"],
         "excludes": ["awscli.examples", "botocore.data"],
     }
-    cx_freeze_opts = {
+    build_msi_options = {
         "add_to_path": True,
         "skip_build": True,
-        "options": {"build_exe": build_exe_options},
+        "upgrade_code": "{799865ae-6f18-4e1a-a396-2ee83b6b46a8}",
+    }
+    cx_freeze_opts = {
+        "options": {"build_exe": build_exe_options, "bdist_msi": build_msi_options},
         "executables": [Executable("bin/nifcloud", icon="assets/icon.ico")],
     }
 else:


### PR DESCRIPTION
# Summary

- Upgrade cx-freeze to 6.15.16
- Add `upgrade_code` option to remove old version before installing new one.
    - The value is randomly generated code.
- Refactor cx-freeze configs.

# Tests

NOTE: these commands must be run on Windows PC.

- [x] `python -m venv .venv`
- [x] `source .venv/Scripts/activate` (if using git bash)
- [x] `pip install pipenv==2023.5.19 setuptools wheel && pipenv install -d --skip-lock --system`
- [x] `python setup.py build` 
- [x] `python setup.py bdist_msi`
- [x] `start dist`
- [x] Run installer and install cli successfully.