### PR TITLE
Fix image ubuntu-22.04 on test workflow for test python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,8 @@ env:
   NIFCLOUD_STORAGE_SECRET_ACCESS_KEY: ${{ secrets.NIFCLOUD_STORAGE_SECRET_ACCESS_KEY }}
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # ubuntu-24.04 later does not support Python 3.7
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 1
       matrix:


### PR DESCRIPTION
## Summary

- Fix workflow test image `utbuntu-latest` to `ubuntu-22.04`

## Detail

- Currently, test workflow fails on `ubuntu-latest`
- `ubuntu-latest` image migrated Ubuntu 24.04
- Python 3.7 version is not available for Ubuntu 24.04 x64
  - https://github.com/actions/setup-python/issues/962#issuecomment-2414418045

## Test

- [x] All checks have passed